### PR TITLE
Install dependencies based on target scheme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+.vscode

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -100,3 +100,34 @@ backup_volsize: 50
 backup_verbosity: 3
 
 backup_exclude: [] # List of filemasks to exlude
+
+# List of packages for schemes
+backup_scheme_deps:
+  azure:
+    - python-azure-storage
+  copy:
+    - python-urllib3
+  fish:
+    - lftp
+  ftp:
+    - lftp
+  ftps:
+    - lftp
+  gs:
+    - python-boto
+  rsync:
+    - rsync
+  mega:
+    - megatools
+  onedrive:
+    - python-requests
+    - python-requests-oauthlib
+  s3:
+    - python-boto
+  scp:
+    - python-paramiko
+  sftp:
+    - python-paramiko
+  swift:
+    - python-swiftclient
+    - python-keystoneclient

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -128,6 +128,12 @@ backup_scheme_deps:
     - python-paramiko
   sftp:
     - python-paramiko
+  pexpect+scp:
+    - openssh-client
+    - python-pexpect
+  pexpect+sftp:
+    - openssh-client
+    - python-pexpect
   swift:
     - python-swiftclient
     - python-keystoneclient

--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -26,3 +26,4 @@
     name: "{{ backup_scheme_deps[item.target | urlsplit('scheme')] }}"
     state: present
   loop: "{{ backup_profiles }}"
+  when: backup_scheme_deps[item.target | urlsplit('scheme')] is defined

--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -12,15 +12,17 @@
     backup_duplicity_pkg: "{{ backup_duplicity_pkg }}={{ backup_duplicity_version }}"
   when: backup_duplicity_version
 
-- name: Install duplicity
-  apt:
-    name: "{{ backup_duplicity_pkg }}"
-    state: present
-
 - name: Install core dependencies
   apt:
     name:
       - cron
       - gzip
       - duply
+      - "{{ backup_duplicity_pkg }}"
     state: present
+
+- name: Install backup profile dependencies
+  apt:
+    name: "{{ backup_scheme_deps[item.target | urlsplit('scheme')] }}"
+    state: present
+  loop: "{{ backup_profiles }}"

--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -1,5 +1,4 @@
 ---
-
 - include_vars: "{{ ansible_distribution }}.yml"
 
 - name: Add duplicity repository
@@ -12,14 +11,18 @@
 - name: Install dependencies
   apt:
     name:
-    - cron
-    - gzip
-    - python-boto
-    - s3cmd
-    - duply
+      - cron
+      - gzip
+      - python-boto
+      - s3cmd
+      - duply
+    state: present
 
-- set_fact: backup_duplicity_pkg="{{ backup_duplicity_pkg }}={{ backup_duplicity_version }}"
+- set_fact: 
+    backup_duplicity_pkg: "{{ backup_duplicity_pkg }}={{ backup_duplicity_version }}"
   when: backup_duplicity_version
 
 - name: Install duplicity
-  apt: pkg={{ backup_duplicity_pkg }} state=present
+  apt:
+    name: "{{ backup_duplicity_pkg }}"
+    state: present

--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -8,16 +8,6 @@
     update_cache: yes
   when: backup_duplicity_ppa
 
-- name: Install dependencies
-  apt:
-    name:
-      - cron
-      - gzip
-      - python-boto
-      - s3cmd
-      - duply
-    state: present
-
 - set_fact: 
     backup_duplicity_pkg: "{{ backup_duplicity_pkg }}={{ backup_duplicity_version }}"
   when: backup_duplicity_version
@@ -25,4 +15,12 @@
 - name: Install duplicity
   apt:
     name: "{{ backup_duplicity_pkg }}"
+    state: present
+
+- name: Install core dependencies
+  apt:
+    name:
+      - cron
+      - gzip
+      - duply
     state: present


### PR DESCRIPTION
This makes the role more flexible by installing only the duplicity dependencies required for your backup targets. This also partially helps with issue #2 because the problem there arises from installing boto for S3 backups. If you aren't doing S3 backups you don't need boto.