### PR TITLE
node exporter/prometheus changes

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -4,7 +4,7 @@
   user: name={{ backup_user }}
 
 - name: backup-configure | Ensure backup user is in node-exporter group
-  user: name={{ backup_user }} group={{ backup_node_exporter_group }} append=yes
+  user: name={{ backup_user }} groups={{ backup_node_exporter_group }} append=yes
   when: backup_prometheus
 
 - name: backup-configure | Ensure backup directories exist

--- a/templates/post.j2
+++ b/templates/post.j2
@@ -16,6 +16,8 @@ rm -rf $WORKDIR/dump
 {% if backup_prometheus %}
 if [ $CMD_ERR = 0 ]; then
   echo backup_time{name=\"{{ item.name }}\"} $(date +%s) > {{ backup_prometheus_dir }}/backup_{{ item.name }}.prom.$$
+  chmod g+r {{ backup_prometheus_dir }}/backup_{{ item.name }}.prom.$$
+  chown $USER:{{ backup_node_exporter_group }} {{ backup_prometheus_dir }}/backup_{{ item.name }}.prom.$$
   mv {{ backup_prometheus_dir }}/backup_{{ item.name }}.prom.$$ {{ backup_prometheus_dir }}/backup_{{ item.name }}.prom
 fi
 {% endif %}


### PR DESCRIPTION
Two changes:

The `group` parameter was used to set the default group of the backup user to the node-exporter group. This PR changes this so the `groups` parameter is used to append a group.

Before this change, when the `backup_node_exporter_group ` was empty but `append` was set, it seems like ansible 2.7.6 removed the user from all groups but the primary group. This is a surprising effect and can be inconvenient.

Because the primary group of the backup user/root is no longer the node-collector group, the status file needed to be chmodded/chowned before it can be read by node-exporter.