### PR TITLE
Add purge commands to purge backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ backup_profiles: []           # Setup backup profiles
                               # Ex. backup_profiles:
                               #       - name: www               # required param
                               #         schedule: 0 0 * * 0     # if defined enabled cronjob
+                              #         purge: 0 0 1 * *        # how often to purge old backups
+                              #         purgeFull: 0 0 1 * *    # how often to purge full backups
+                              #         purgeIncr: 0 0 * * 0    # how often to purge incremental backups
                               #         source: /var/www
                               #         max_age: 10D
                               #         target: s3://my.bucket/www
@@ -108,6 +111,9 @@ backup_max_age: 1M
 # Number of full backups to keep. Used for the "purge-full" command.
 # See duplicity man page, action "remove-all-but-n-full".
 backup_max_full_backups: 1
+
+# Number of full backups to keep with associated incrementals
+backup_max_fulls_with_incrs: 1
 
 # forces a full backup if last full backup reaches a specified age
 backup_full_max_age: 1M

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,6 +39,9 @@ backup_profiles: []           # Setup backup profiles
                               # Ex. backup_profiles:
                               #       - name: www               # required param
                               #         schedule: 0 0 * * 0     # if defined enabled cronjob
+                              #         purge: 0 0 1 * *        # how often to purge old backups
+                              #         purgeFull: 0 0 1 * *    # how often to purge full backups
+                              #         purgeIncr: 0 0 * * 0    # how often to purge incremental backups
                               #         source: /var/www
                               #         max_age: 10D
                               #         target: s3://my.bucket/www
@@ -89,6 +92,9 @@ backup_max_age: 1M
 # Number of full backups to keep. Used for the "purge-full" command.
 # See duplicity man page, action "remove-all-but-n-full".
 backup_max_full_backups: 1
+
+# Number of full backups to keep with associated incrementals
+backup_max_fulls_with_incrs: 1
 
 # forces a full backup if last full backup reaches a specified age
 backup_full_max_age: 1M

--- a/templates/conf.j2
+++ b/templates/conf.j2
@@ -43,6 +43,9 @@ MAX_AGE={{ item.max_age|default(backup_max_age)|quote }}
 # See duplicity man page, action "remove-all-but-n-full".
 MAX_FULL_BACKUPS='{{ item.max_full_backups|default(backup_max_full_backups)}}'
 
+# Number of full backups to keep with associated incrementals
+MAX_FULLS_WITH_INCRS='{{ item.max_fulls_with_incrs|default(backup_max_fulls_with_incrs)}}'
+
 VERBOSITY={{ item.verbosity|default(backup_verbosity)}}
 
 # ARCH_DIR=/tmp/backup_{{ item.name }}

--- a/templates/cron.j2
+++ b/templates/cron.j2
@@ -7,12 +7,12 @@
 {{ profile.schedule }} {{ profile.user|default(backup_user)}} /usr/bin/duply {{ backup_home }}/{{ profile.name }} {{ profile.action|default('backup')}} >> {{ backup_logdir }}/{{ profile.name }}.log 2>&1
 {% endif %}
 {% if profile.purge|default(None) %}
-{{ profile.purge }} {{ profile.user|default(backup_user)}} /usr/bin/duply {{ backup_home }}/{{ profile.name }} purge >> {{ backup_logdir }}/{{ profile.name }}_purge.log 2>&1
+{{ profile.purge }} {{ profile.user|default(backup_user)}} /usr/bin/duply {{ backup_home }}/{{ profile.name }} purge --force >> {{ backup_logdir }}/{{ profile.name }}_purge.log 2>&1
 {% endif %}
 {% if profile.purgeFull|default(None) %}
-{{ profile.purgeFull }} {{ profile.user|default(backup_user)}} /usr/bin/duply {{ backup_home }}/{{ profile.name }} purgeFull >> {{ backup_logdir }}/{{ profile.name }}_purgeFull.log 2>&1
+{{ profile.purgeFull }} {{ profile.user|default(backup_user)}} /usr/bin/duply {{ backup_home }}/{{ profile.name }} purgeFull --force >> {{ backup_logdir }}/{{ profile.name }}_purgeFull.log 2>&1
 {% endif %}
 {% if profile.purgeIncr|default(None) %}
-{{ profile.purgeIncr }} {{ profile.user|default(backup_user)}} /usr/bin/duply {{ backup_home }}/{{ profile.name }} purgeIncr >> {{ backup_logdir }}/{{ profile.name }}_purgeIncr.log 2>&1
+{{ profile.purgeIncr }} {{ profile.user|default(backup_user)}} /usr/bin/duply {{ backup_home }}/{{ profile.name }} purgeIncr --force >> {{ backup_logdir }}/{{ profile.name }}_purgeIncr.log 2>&1
 {% endif %}
 {% endfor %}

--- a/templates/cron.j2
+++ b/templates/cron.j2
@@ -6,4 +6,13 @@
 {% if profile.schedule|default(None) %}
 {{ profile.schedule }} {{ profile.user|default(backup_user)}} /usr/bin/duply {{ backup_home }}/{{ profile.name }} {{ profile.action|default('backup')}} >> {{ backup_logdir }}/{{ profile.name }}.log 2>&1
 {% endif %}
+{% if profile.purge|default(None) %}
+{{ profile.purge }} {{ profile.user|default(backup_user)}} /usr/bin/duply {{ backup_home }}/{{ profile.name }} purge >> {{ backup_logdir }}/{{ profile.name }}_purge.log 2>&1
+{% endif %}
+{% if profile.purgeFull|default(None) %}
+{{ profile.purgeFull }} {{ profile.user|default(backup_user)}} /usr/bin/duply {{ backup_home }}/{{ profile.name }} purgeFull >> {{ backup_logdir }}/{{ profile.name }}_purgeFull.log 2>&1
+{% endif %}
+{% if profile.purgeIncr|default(None) %}
+{{ profile.purgeIncr }} {{ profile.user|default(backup_user)}} /usr/bin/duply {{ backup_home }}/{{ profile.name }} purgeIncr >> {{ backup_logdir }}/{{ profile.name }}_purgeIncr.log 2>&1
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
The current role has the max age and max full backups variables but doesn't actually run the purge command to clean out backups older than the variables. This adds cron jobs to run the purge commands and clean up older backups.