### PR TITLE
Update location of PPA

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -4,7 +4,7 @@
 
 - name: Add duplicity repository
   apt_repository:
-    repo: ppa:duplicity-team/ppa
+    repo: ppa:duplicity-team/duplicity-release-git
     state: present
     update_cache: yes
   when: backup_duplicity_ppa


### PR DESCRIPTION
The old duplicity PPA has been removed: https://launchpad.net/duplicity/+announcement/17190

For those who still wish to enable the PPA, this updates it to the new one which tracks 0.8 series releases.