### PR TITLE
Add MySQL host param for mysqldump

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,6 +29,7 @@ backup_postgres_host: ""
 backup_postgres_port: 5432
 
 # Mysql
+backup_mysql_host: ""
 backup_mysql_user: ""
 backup_mysql_pass: ""
 

--- a/templates/pre.j2
+++ b/templates/pre.j2
@@ -19,7 +19,7 @@ DBNAME='--all-databases'
 DBNAME={{ item.source.split('mysql://')[-1]}}
 {% endif %}
 
-mysqldump --skip-lock-tables --single-transaction {{ '-u %s' % backup_mysql_user if backup_mysql_user else '' }} {{ '-p%s' % (backup_mysql_pass|quote) if backup_mysql_pass else '' }} $DBNAME  > ${WORKDIR}/dump
+mysqldump --skip-lock-tables --single-transaction {{ ('-h %s' % backup_mysql_host) if backup_mysql_host else ''}} {{ '-u %s' % backup_mysql_user if backup_mysql_user else '' }} {{ '-p%s' % (backup_mysql_pass|quote) if backup_mysql_pass else '' }} $DBNAME  > ${WORKDIR}/dump
 
 {% elif item.source.startswith('mongo://') %}
 

--- a/templates/restore.j2
+++ b/templates/restore.j2
@@ -22,11 +22,11 @@ rm -rf $WORKDIR/dump
 
 {% if item.source == 'mysql://' %}
 # Restore all databases
-mysql {{ '-u %s' % backup_mysql_user if backup_mysql_user else '' }} {{ '-p%s' % (backup_mysql_pass|quote) if backup_mysql_pass else '' }} < ${WORKDIR}/dump
+mysql {{ '-u %s' % backup_mysql_user if backup_mysql_user else '' }} {{ ('-h %s' % backup_mysql_host) if backup_mysql_host else ''}} {{ '-p%s' % (backup_mysql_pass|quote) if backup_mysql_pass else '' }} < ${WORKDIR}/dump
 {% else %}
 # Restore the passed database
 DBNAME={{ item.source.split('mysql://')[-1]}}
-mysql {{ '-u %s' % backup_mysql_user if backup_mysql_user else '' }} {{ '-p%s' % (backup_mysql_pass|quote) if backup_mysql_pass else '' }} $DBNAME  < ${WORKDIR}/dump
+mysql {{ '-u %s' % backup_mysql_user if backup_mysql_user else '' }} {{ ('-h %s' % backup_mysql_host) if backup_mysql_host else ''}} {{ '-p%s' % (backup_mysql_pass|quote) if backup_mysql_pass else '' }} $DBNAME  < ${WORKDIR}/dump
 rm -rf $WORKDIR/dump
 {% endif %}
 


### PR DESCRIPTION
The role currently only allows for localhost mysqldump's. This adds a `backup_mysql_host`.

Fixes:
```shell
mysqldump: Got error: 2002: "Can't connect to local MySQL server through socket '/run/mysqld/mysqld.sock' (2)" when trying to connect
```