### PR TITLE
Use python3 packages in Debian >= 11 and Ubuntu >= 20

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-system_python_version: "{{ (ansible_distribution_release == 'focal') | ternary('3', '') }}"
 
 backup_enabled: yes             # Enable the role
 backup_remove: no               # Set yes for uninstall the role from target system

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,3 +1,4 @@
 ---
 
 backup_duplicity_ppa: false
+system_python_version: "{{ (ansible_distribution_major_version >= '11') | ternary('3', '') }}"

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -1,1 +1,3 @@
 ---
+
+system_python_version: "{{ (ansible_distribution_major_version >= '20') | ternary('3', '') }}"


### PR DESCRIPTION
Hello,

This moves the system python version into the OS 'vars' files. Not only does this fix support for Debian Bullseye and higher, but it also future-proofs your Ubuntu systems once you upgrade beyond Focal.

Thanks!