### PR TITLE
Update tasks to Ansible 12 compatible syntax

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,13 +1,14 @@
 ---
 
 - name: backup-configure | Ensure backup user exists
-  user: name={{ backup_user }}
+  user:
+    name: {{ backup_user }}
 
 - name: backup-configure | Ensure node-exporter group exists
   group:
     name: "{{ backup_node_exporter_group }}"
     system: yes
-  when: backup_prometheus
+  when: backup_prometheus | bool
 
 - name: backup-configure | Ensure backup users are in node-exporter group
   user:
@@ -18,7 +19,11 @@
   with_items: "{{ backup_profiles }}"
 
 - name: backup-configure | Ensure backup directories exist
-  file: path={{ item }} state=directory owner={{ backup_user }} group={{ backup_group }}
+  file:
+    path: {{ item }}
+    state: directory
+    owner: {{ backup_user }}
+    group: {{ backup_group }}
   with_items:
   - "{{ backup_home }}"
   - "{{ item.work_dir|default(backup_work) }}"
@@ -114,7 +119,10 @@
     weekday: "{{ item.schedule.split(' ')[4] }}"
     name: "{{ item.name }}"
   loop: "{{ backup_profiles }}"
-  when: backup_cron and item.schedule|default(None)
+  when:
+    - backup_cron | bool
+    - item.schedule is defined
+    - item.schedule | length > 0
 
 - name: backup-configure | Create log files
   file:

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -2,7 +2,7 @@
 
 - name: backup-configure | Ensure backup user exists
   user:
-    name: {{ backup_user }}
+    name: "{{ backup_user }}"
 
 - name: backup-configure | Ensure node-exporter group exists
   group:
@@ -20,10 +20,10 @@
 
 - name: backup-configure | Ensure backup directories exist
   file:
-    path: {{ item }}
+    path: "{{ item }}"
     state: directory
-    owner: {{ backup_user }}
-    group: {{ backup_group }}
+    owner: "{{ backup_user }}"
+    group: "{{ backup_group }}"
   with_items:
   - "{{ backup_home }}"
   - "{{ item.work_dir|default(backup_work) }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -17,7 +17,7 @@
 
 - set_fact:
     backup_duplicity_pkg: "{{ backup_duplicity_pkg }}={{ backup_duplicity_version }}"
-  when: backup_duplicity_version
+  when: backup_duplicity_version is defined and backup_duplicity_version is not none
 
 - name: Install core dependencies
   apt:

--- a/tasks/remove.yml
+++ b/tasks/remove.yml
@@ -9,7 +9,7 @@
 - name: Uninstall the role - pt. 2
   file:
     state: absent
-    path: {{ item }}
+    path: "{{ item }}"
   with_items:
   - "{{ backup_home }}"
   - "{{ item.work_dir|default(backup_work) }}"

--- a/tasks/remove.yml
+++ b/tasks/remove.yml
@@ -2,10 +2,14 @@
 # Uninstall the role
 
 - name: Uninstall the role - pt. 1
-  file: state=absent path=/etc/cron.d/backup
+  file:
+    state: absent
+    path: /etc/cron.d/backup
 
 - name: Uninstall the role - pt. 2
-  file: state=absent path={{ item }}
+  file:
+    state: absent
+    path: {{ item }}
   with_items:
   - "{{ backup_home }}"
   - "{{ item.work_dir|default(backup_work) }}"


### PR DESCRIPTION
Ansible 12 is stricter about conditionals and variable types. This cleans up the role so it runs cleanly after the upgrade:
- make `when` conditions explicit (no implicit truthiness)
- fix `set_fact` usage to preserve correct types